### PR TITLE
add no browser field for budo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "dist/aframe-bmfont-text-component.min.js",
   "scripts": {
     "build": "browserify examples/main.js -o examples/build.js",
-    "dev": "budo examples/main.js:build.js --dir examples --port 8000 --live --open",
+    "dev": "budo examples/main.js:build.js --dir examples --port 8000 --live --open -- --no-browser-field",
     "dist": "webpack index.js dist/aframe-bmfont-text-component.js && webpack -p index.js dist/aframe-bmfont-text-component.min.js",
     "postpublish": "npm run dist",
     "preghpages": "npm run build && rm -rf gh-pages && cp -r examples gh-pages",


### PR DESCRIPTION
This was causing the `dist` to be served in development.
